### PR TITLE
Improve completion

### DIFF
--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -149,7 +149,7 @@ fun! NimComplete(findstart, base)
       let lineData = split(line, '\t')
       if len(lineData) > 0 && lineData[0] == "sug"
         let word = lineData[2]
-        if a:base ==# word[: baselen - 1]
+        if a:base ==# word[: baselen - 1]  || baselen == 0
           let kind = get(g:nim_symbol_types, lineData[1], '')
           let c = { 'word': word, 'kind': kind, 'menu': lineData[3], 'dup': 1 }
           call add(result, c)

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -139,7 +139,7 @@ fun! NimComplete(findstart, base)
     endif
 
     let curline = getline(line('.'))
-    return curcol - match(reverse(split(curline, '\zs')), '[^0-9a-zA-Z_]') - 1
+    return curcol - match(reverse(split(curline, '\zs')), '\W') - 1
   else
     let result = []
     let sugOut = NimExec("--suggest")

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -131,21 +131,29 @@ fun! NimComplete(findstart, base)
   if b:nim_caas_enabled == 0
     return -1
   endif
+  let curcol = col('.')
 
   if a:findstart
     if synIDattr(synIDtrans(synID(line("."),col("."),1)), "name") == 'Comment'
       return -1
     endif
-    return col('.')
+
+    let curline = getline(line('.'))
+    return curcol - match(reverse(split(curline, '\zs')), '[^0-9a-zA-Z_]') - 1
   else
     let result = []
     let sugOut = NimExec("--suggest")
+    let baselen = len(a:base)
+
     for line in split(sugOut, '\n')
       let lineData = split(line, '\t')
       if len(lineData) > 0 && lineData[0] == "sug"
-        let kind = get(g:nim_symbol_types, lineData[1], '')
-        let c = { 'word': lineData[2], 'kind': kind, 'menu': lineData[3], 'dup': 1 }
-        call add(result, c)
+        let word = lineData[2]
+        if a:base ==# word[: baselen - 1]
+          let kind = get(g:nim_symbol_types, lineData[1], '')
+          let c = { 'word': word, 'kind': kind, 'menu': lineData[3], 'dup': 1 }
+          call add(result, c)
+        endif
       endif
     endfor
     return result

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -149,9 +149,9 @@ fun! NimComplete(findstart, base)
       let lineData = split(line, '\t')
       if len(lineData) > 0 && lineData[0] == "sug"
         let word = lineData[2]
-        if a:base ==# word[: baselen - 1]  || baselen == 0
+        if a:base ==# word[: baselen - 1] || baselen == 0
           let kind = get(g:nim_symbol_types, lineData[1], '')
-          let c = { 'word': word, 'kind': kind, 'menu': lineData[3], 'dup': 1 }
+          let c = {'word': word, 'kind': kind, 'menu': lineData[3], 'dup': 1}
           call add(result, c)
         endif
       endif

--- a/autoload/nim.vim
+++ b/autoload/nim.vim
@@ -155,8 +155,13 @@ endf
 if !exists("g:neocomplcache_omni_patterns")
   let g:neocomplcache_omni_patterns = {}
 endif
-
 let g:neocomplcache_omni_patterns['nim'] = '[^. *\t]\.\w*'
+
+if !exists('g:neocomplete#sources#omni#input_patterns')
+  let g:neocomplete#sources#omni#input_patterns = {}
+endif
+let g:neocomplete#sources#omni#input_patterns['nim'] = '[^. *\t]\.\w*'
+
 let g:nim_completion_callbacks = {}
 
 fun! NimAsyncCmdComplete(cmd, output)


### PR DESCRIPTION
Omni-completion fails in some cases.

### Example of bad case

Use this minimum .vimrc (save as `compl.vim`).

```vim
" Load nimrod.vim
set runtimepath+=~/.vim/bundle/nimrod.vim
filetype plugin indent on
syntax on
```

And open the following nim file (save as compl.nim).

```nim
type
  Socket* = object of RootObj
    FHost: int
    ab: int
    acdf: int
    aa: int
    aavv: string
    sasd: int

var s: Socket
echo s.a
```

```sh
vim -u compl.vim -N compl.nim
```

At the end of the last line, press `<C-x><C-o>`. 

This is a screen shot. The result of completions is invalid, since **the existing word "a" is ignored**.

![nimrod_compl_orig](https://cloud.githubusercontent.com/assets/3213998/5987121/9ec8ad16-a95e-11e4-8541-bf940fc05638.png)

### After applying changes of this PR.

Do same as above. This is a screen shot.

![nimrod_compl_improved](https://cloud.githubusercontent.com/assets/3213998/5987122/a3bc71d6-a95e-11e4-9ada-076e7b9babd3.png)

Regards